### PR TITLE
Deserialize Materials and Rocket League InvisiTekMaterials as Objects instead of None

### DIFF
--- a/Unreal-Library/Core/Classes/UDefaultProperty.cs
+++ b/Unreal-Library/Core/Classes/UDefaultProperty.cs
@@ -675,6 +675,12 @@ namespace UELib.Core
                                     arrayType = varTuple.Item2;
                                 }
                             }
+                            // Hardcoded fix for Materials and Rocket League InvisiTekMaterials
+                            // which have a PropertyType of None when loaded for some reason.
+                            else if ((Name == "Materials" || Name == "InvisiTekMaterials") && _Outer?.Name == "StaticMeshComponent")
+                            {
+                                arrayType = PropertyType.ObjectProperty;
+                            }
 
                             if( arrayType == PropertyType.None )
                             {


### PR DESCRIPTION
With that fix, the material arrays are showing the correct info.

This is probably not the best way to do it, but it does the job. Another way would be to make sure that the Materials PropertyType is set to 'Object' instead of 'None' on package load. However, I couldn't find where that logic was exactly.